### PR TITLE
renamed make->makefile and made it real makefile.

### DIFF
--- a/source/parser/dbase/makefile
+++ b/source/parser/dbase/makefile
@@ -1,0 +1,27 @@
+COMPILER ?= g++
+#COMPILER = the c++ compiler to use.
+#  or, on command line, supply the value:
+#    make COMPILER=g++
+###########################################
+yymaincc:
+	$(COMPILER) -c \
+-Wno-unused-parameter \
+-Wno-unused-variable \
+-Wno-unused-local-typedefs \
+-Wno-unused-but-set-variable \
+-Wno-write-strings \
+-Wno-extra \
+-Wno-reorder \
+-Wunused-function \
+-Woverloaded-virtual \
+-fpermissive \
+-ftemplate-depth=200 -frtti -fexceptions -std=c++17 \
+-D__BYTE_ORDER=__LITTLE_ENDIAN -D_REENTRANT -fPIC \
+-DBUILDTIME=\"14:43:09\" -DBUILDDATE=\"2016-08-22\" \
+-I. \
+-I/usr/include \
+\
+-o yymain.o yymain.cc
+
+show:
+	@echo "COMPILER=$(COMPILER)"


### PR DESCRIPTION
Hi Jens,

This is the change I suggested in my reply to you in spirit-general:

https://sourceforge.net/p/spirit/mailman/spirit-general/thread/npl8j4%24k9f%241%40blaine.gmane.org/#msg35300080

This allows me to use the only g++ compiler on my system which accepts the -std=c++17 flag.
I use it as follows:

make COMPILER=/home/evansl/dwnlds/gcc/5.2.0/install/bin/g++

However, as noted in my spirit-general reply, I'm still getting errors such as:

yymain.cc:82:5: error: ‘QVector’ does not name a type
     QVector <QString> vec_push;
     ^
yymain.cc: In constructor ‘dBaseParser::expression_ast::expression_ast(const string&, const string&, const string&)’:
yymain.cc:201:9: error: ‘QString’ was not declared in this scope
         QString str = oper.c_str();
         ^

Somehow, you also need to replace all those missing Q{whatever} with something
that doesn't require some other library such as qt5 or whatever.

HTH.

-Larry
